### PR TITLE
Update to zig 0.15.0-dev.377+f01833e03

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.0-dev.377+f01833e03
       - run: zig build -Dtarget=${{ matrix.target }}
       - name: zip artifact
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,5 +18,5 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.0-dev.377+f01833e03
       - run: zig fmt --check .

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: mlugg/setup-zig@v1
         with:
-          version: 0.13.0
+          version: 0.15.0-dev.377+f01833e03
       - run: zig build && zig build test
   check-fmt:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.zig-cache
+zig-out

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,7 @@
 .{
-    .name = "zosc",
+    .name = .zosc,
     .version = "0.1.0",
+    .fingerprint = 0xb6e4092e18114363,
     .paths = .{ "build.zig.zon", "build.zig", "src", "include", "LICENSE", "README.org" },
     .dependencies = .{},
 }

--- a/src/bundle.zig
+++ b/src/bundle.zig
@@ -34,7 +34,7 @@ pub fn toBytes(self: *const Bundle) []const u8 {
 pub fn fromBytes(allocator: std.mem.Allocator, buffer: []const u8) (std.mem.Allocator.Error || error{BadBufferData})!*Bundle {
     if (buffer.len % 4 != 0) return error.BadBufferData;
     if (!std.mem.startsWith(u8, buffer, "#bundle\x00")) return error.BadBufferData;
-    const allocation = try allocator.alignedAlloc(u8, @max(4, @alignOf(Header)), pad(buffer.len) + pad(@sizeOf(Header)));
+    const allocation = try allocator.alignedAlloc(u8, .max(.@"4", .fromByteUnits(@alignOf(Header))), pad(buffer.len) + pad(@sizeOf(Header)));
     errdefer allocator.free(allocation);
     const header: *Header = @ptrCast(allocation.ptr);
     const time: TimeTag = @bitCast(std.mem.readInt(u64, buffer[8..16], .big));
@@ -51,7 +51,7 @@ pub fn fromBytes(allocator: std.mem.Allocator, buffer: []const u8) (std.mem.Allo
 }
 
 pub fn build(allocator: std.mem.Allocator, tag: TimeTag, content: []const u8) std.mem.Allocator.Error!*Bundle {
-    const allocation = try allocator.alignedAlloc(u8, @max(4, @alignOf(Header)), pad(@sizeOf(Header)) + 16 + content.len);
+    const allocation = try allocator.alignedAlloc(u8, .max(.@"4", .fromByteUnits(@alignOf(Header))), pad(@sizeOf(Header)) + 16 + content.len);
     const header: *Header = @ptrCast(allocation.ptr);
     var ptr: [*]u8 = allocation.ptr + pad(@sizeOf(Header));
     @memcpy(ptr[0..8], "#bundle\x00");
@@ -67,11 +67,11 @@ pub fn build(allocator: std.mem.Allocator, tag: TimeTag, content: []const u8) st
 }
 
 pub const Builder = struct {
-    data: std.ArrayListAligned(u8, 4),
+    data: std.ArrayListAligned(u8, .@"4"),
 
     pub fn init(allocator: std.mem.Allocator) Builder {
         return .{
-            .data = std.ArrayListAligned(u8, 4).init(allocator),
+            .data = .init(allocator),
         };
     }
 

--- a/src/data.zig
+++ b/src/data.zig
@@ -75,14 +75,14 @@ pub const Data = union(TypeTag) {
     pub fn from(comptime T: type, item: T) Data {
         const info = @typeInfo(T);
         return switch (info) {
-            .Int => .{ .i = @intCast(item) },
-            .ComptimeInt => .{ .i = item },
-            .Float => .{ .f = @floatCast(item) },
-            .ComptimeFloat => .{ .f = item },
-            .Pointer => .{ .s = item },
-            .Bool => if (item) .T else .F,
-            .Null => .N,
-            .EnumLiteral => .I,
+            .int => .{ .i = @intCast(item) },
+            .comptime_int => .{ .i = item },
+            .float => .{ .f = @floatCast(item) },
+            .comptime_float => .{ .f = item },
+            .pointer => .{ .s = item },
+            .bool => if (item) .T else .F,
+            .null => .N,
+            .enum_literal => .I,
             else => @compileError("cannot produce Data from this type!"),
         };
     }
@@ -101,8 +101,8 @@ pub const Data = union(TypeTag) {
             },
             inline .f, .d => |float| blk: {
                 const T = @TypeOf(float);
-                const size = @divExact(@typeInfo(T).Float.bits, 8);
-                const I = @Type(.{ .Int = .{
+                const size = @divExact(@typeInfo(T).float.bits, 8);
+                const I = @Type(.{ .int = .{
                     .bits = size * 8,
                     .signedness = .unsigned,
                 } });

--- a/src/message.zig
+++ b/src/message.zig
@@ -48,7 +48,7 @@ test toBytes {
 pub fn fromBytes(allocator: std.mem.Allocator, buffer: []const u8) (std.mem.Allocator.Error || error{BadBufferData})!*Message {
     if (buffer.len % 4 != 0) return error.BadBufferData;
     if (buffer[0] != '/') return error.BadBufferData;
-    const allocation = try allocator.alignedAlloc(u8, @max(4, @alignOf(Header)), buffer.len + pad(@sizeOf(Header)));
+    const allocation = try allocator.alignedAlloc(u8, .max(.@"4", .fromByteUnits(@alignOf(Header))), buffer.len + pad(@sizeOf(Header)));
     errdefer allocator.free(allocation);
     const header: *Header = @ptrCast(allocation.ptr);
     const address_len = std.mem.indexOfScalar(u8, buffer, 0) orelse return error.BadBufferData;
@@ -178,7 +178,7 @@ pub fn build(allocator: std.mem.Allocator, path: []const u8, types: []const u8, 
     const types_len = pad(types.len + 1);
     const header_len = pad(@sizeOf(Header));
     const size = path_len + types_len + data.len + header_len;
-    const allocation = try allocator.alignedAlloc(u8, @max(4, @alignOf(Header)), size);
+    const allocation = try allocator.alignedAlloc(u8, .max(.@"4", .fromByteUnits(@alignOf(Header))), size);
     const header: *Header = @ptrCast(allocation.ptr);
     var ptr: [*]u8 = allocation.ptr + header_len;
     @memcpy(ptr, path);
@@ -260,7 +260,7 @@ pub const Builder = struct {
             .data = .{},
         };
         errdefer self.deinit();
-        const info = @typeInfo(@TypeOf(tuple)).Struct;
+        const info = @typeInfo(@TypeOf(tuple)).@"struct";
         comptime std.debug.assert(info.is_tuple);
         inline for (info.fields, 0..) |field, i| {
             try self.append(Data.from(field.type, tuple[i]));

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -96,7 +96,7 @@ pub const Parse = union(enum) {
             var ret: T = undefined;
             if (!matchTypes(types, self.types)) return error.TypeMismatch;
             const info = @typeInfo(T);
-            inline for (info.Struct.fields, 0..) |field, i| {
+            inline for (info.@"struct".fields, 0..) |field, i| {
                 ret[i] = try unpackNext(field.type, self);
             }
             return ret;
@@ -105,12 +105,12 @@ pub const Parse = union(enum) {
         fn unpackNext(comptime T: type, self: *MessageIterator) error{ TypeMismatch, InvalidOSC }!T {
             const datum = try self.next() orelse return error.TypeMismatch;
             const info = @typeInfo(T);
-            if (info == .ErrorUnion) {
+            if (info == .error_union) {
                 if (datum == .I) return error.Bang;
-                const child_info = @typeInfo(info.ErrorUnion.payload);
-                if (child_info == .Optional) {
+                const child_info = @typeInfo(info.error_union.payload);
+                if (child_info == .optional) {
                     if (datum == .N) return null;
-                    return switch (child_info.Optional.child) {
+                    return switch (child_info.optional.child) {
                         i32 => if (datum != .i) error.TypeMismatch else datum.i,
                         f32 => if (datum != .f) error.TypeMismatch else datum.f,
                         []const u8 => switch (datum) {
@@ -129,7 +129,7 @@ pub const Parse = union(enum) {
                         else => @compileError("unexpected type!"),
                     };
                 }
-                return switch (info.ErrorUnion.payload) {
+                return switch (info.error_union.payload) {
                     i32 => if (datum != .i) error.TypeMismatch else datum.i,
                     f32 => if (datum != .f) error.TypeMismatch else datum.f,
                     []const u8 => switch (datum) {
@@ -149,9 +149,9 @@ pub const Parse = union(enum) {
                     else => @compileError("unexpected type!"),
                 };
             }
-            if (info == .Optional) {
+            if (info == .optional) {
                 if (datum == .N) return null;
-                return switch (info.Optional.child) {
+                return switch (info.optional.child) {
                     i32 => if (datum != .i) error.TypeMismatch else datum.i,
                     f32 => if (datum != .f) error.TypeMismatch else datum.f,
                     []const u8 => switch (datum) {
@@ -215,7 +215,7 @@ pub const Parse = union(enum) {
                     };
                     fields = fields ++ .{field};
                 }
-                return @Type(.{ .Struct = .{
+                return @Type(.{ .@"struct" = .{
                     .layout = .auto,
                     .fields = fields,
                     .decls = &.{},


### PR DESCRIPTION
Hello! I was checking out [seamstress](https://github.com/robbielyman/seamstress) and working through some of the Zig upgrade dredgery and it involved updating some aspects of this library too, as it's a dependency.

(Note: I tested on Zig 0.15.0-dev.377+f01833e03 because is the latest as of time of writing.)

I kept iterating until `zig build` and `zig build test` completed without errors on my machine. Overall, nothing major. In summary:
- Added gitignore
- Updated build.zig.zon fields
- Updated Alignment usage (double check this for me - there might need to be some tweaking)
- Updated usage of std.builtin.Type union